### PR TITLE
Update actions to comply with new version of craft ai

### DIFF
--- a/src/actions/GetCurrentPOSIXTime.py
+++ b/src/actions/GetCurrentPOSIXTime.py
@@ -27,7 +27,6 @@ def registerAction(user, project, version, sim_id):
 def start():
 	request_Id = request.json['requestId']
 	output_json = json.dumps({'currentPOSIXTime': int(time.time())})
-	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 	r = requests.post(success_url, data=output_json, headers = json_headers)

--- a/src/actions/GetCurrentPOSIXTime.py
+++ b/src/actions/GetCurrentPOSIXTime.py
@@ -30,8 +30,7 @@ def start():
 	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-	r = requests.post(output_url, data=output_json, headers = json_headers)
-	r = requests.post(success_url)
+	r = requests.post(success_url, data=output_json, headers = json_headers)
 	return 
 
 def cancel():

--- a/src/actions/GetCurrentStrTime.py
+++ b/src/actions/GetCurrentStrTime.py
@@ -28,7 +28,6 @@ def start():
 	request_Id = request.json['requestId']
 	now = datetime.now()
 	output_json = json.dumps({'currentStrTime': now.strftime('%Y-%m-%dT%H:%M:%S')})
-	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 	r = requests.post(success_url, data=output_json, headers = json_headers)

--- a/src/actions/GetCurrentStrTime.py
+++ b/src/actions/GetCurrentStrTime.py
@@ -31,8 +31,7 @@ def start():
 	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-	r = requests.post(output_url, data=output_json, headers = json_headers)
-	r = requests.post(success_url)
+	r = requests.post(success_url, data=output_json, headers = json_headers)
 	return 
 
 def cancel():

--- a/src/actions/GetTimeDiff.py
+++ b/src/actions/GetTimeDiff.py
@@ -34,7 +34,6 @@ def start():
 	time2 = parser.parse(inputParams['time2'])
 	timeDiff = time2 - time1
 	output_json = json.dumps({'timeDiff': timeDiff.total_seconds()})
-	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 	r = requests.post(success_url, data=output_json, headers = json_headers)

--- a/src/actions/GetTimeDiff.py
+++ b/src/actions/GetTimeDiff.py
@@ -37,8 +37,7 @@ def start():
 	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-	r = requests.post(output_url, data=output_json, headers = json_headers)
-	r = requests.post(success_url)
+	r = requests.post(success_url, data=output_json, headers = json_headers)
 	return 
 
 def cancel():

--- a/src/actions/Sum.py
+++ b/src/actions/Sum.py
@@ -29,7 +29,6 @@ def start():
 
 	request_Id = request.json['requestId']
 	output_json = json.dumps({"result": (inputParams['term1'] + inputParams['term2'])})
-	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 	r = requests.post(success_url, data=output_json, headers = json_headers)

--- a/src/actions/Sum.py
+++ b/src/actions/Sum.py
@@ -32,8 +32,7 @@ def start():
 	output_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/output'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	success_url = '{}/api/v1/{}/{}/{}/{}/actions/{}/success'.format(runtime.CRAFT_RUNTIME_SERVER_URL, sim_parameters['user'],sim_parameters['project'],sim_parameters['version'],sim_parameters['sim_id'], request_Id)
 	json_headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-	r = requests.post(output_url, data=output_json, headers = json_headers)
-	r = requests.post(success_url)
+	r = requests.post(success_url, data=output_json, headers = json_headers)
 	return 
 
 def cancel():


### PR DESCRIPTION
> Taking into account the new lifetime of actions requests (cf. 18/08/2015 [changelog](http://doc.craft.ai/index.html#18-08-2015))

* action requests outputs are now sent in "success" routes