### PR TITLE
HTTPS and BT path instead of BT names

### DIFF
--- a/local_demo.py
+++ b/local_demo.py
@@ -64,7 +64,7 @@ os.environ["CRAFT_DEMO_SAC_APP_SECRET"] = config['sac_app_secret']
 os.environ["CRAFT_DEMO_SAC_PORT"] = '8080'
 os.environ["CRAFT_DEMO_SAC_URL"] = 'http://localhost:8080'
 os.environ["CRAFT_DEMO_SAC_WS_URL"] = 'ws://localhost:8080'
-os.environ["CRAFT_RUNTIME_SERVER_URL"] = 'http://runtime.craft.ai'
+os.environ["CRAFT_RUNTIME_SERVER_URL"] = 'https://runtime.craft.ai'
 os.environ["CRAFT_DEMO_SAC_ACTIONS_URL"] = public_url
 
 subprocess.call(["python", "-u", "src/server/main.py"])

--- a/src/decision/AlertManager.bt
+++ b/src/decision/AlertManager.bt
@@ -185,7 +185,7 @@
 										},
 										"properties": {
 											"behavior": {
-												"value": "FormatMessage",
+												"value": "src/decision/FormatMessage.bt",
 												"type": "string"
 											},
 											"inputParams": []

--- a/src/decision/ContextualAlerts.bt
+++ b/src/decision/ContextualAlerts.bt
@@ -37,7 +37,7 @@
 						},
 						"properties": {
 							"behavior": {
-								"value": "MainInitialization",
+								"value": "src/decision/MainInitialization.bt",
 								"type": "string"
 							},
 							"inputParams": []
@@ -84,7 +84,7 @@
 								},
 								"properties": {
 									"behavior": {
-										"value": "MainUpdate",
+										"value": "src/decision/MainUpdate.bt",
 										"type": "string"
 									},
 									"inputParams": []

--- a/src/decision/MainInitialization.bt
+++ b/src/decision/MainInitialization.bt
@@ -97,7 +97,7 @@
 								},
 								"properties": {
 									"behavior": {
-										"value": "GetGoogleCredentials",
+										"value": "src/decision/GetGoogleCredentials.bt",
 										"type": "string"
 									},
 									"inputParams": []
@@ -119,7 +119,7 @@
 								},
 								"properties": {
 									"behavior": {
-										"value": "InitGoogleServices",
+										"value": "src/decision/InitGoogleServices.bt",
 										"type": "string"
 									},
 									"inputParams": []

--- a/src/decision/MainUpdate.bt
+++ b/src/decision/MainUpdate.bt
@@ -459,7 +459,7 @@
                     },
                     "properties": {
                       "behavior": {
-                        "value": "AlertManager",
+                        "value": "src/decision/AlertManager.bt",
                         "type": "string"
                       },
                       "inputParams": []

--- a/src/server/helper.py
+++ b/src/server/helper.py
@@ -127,7 +127,7 @@ def run_simulation():
 		data['cred_google'] = stateVar.cred
 
 		# Create life entity
-		stateVar.entityId = runtime.create_entity(CRAFT_DEMO_SAC_USER, CRAFT_DEMO_SAC_PROJECT, CRAFT_DEMO_SAC_VERSION, simulation_id,'craft:ContextualAlerts.bt',  data)
+		stateVar.entityId = runtime.create_entity(CRAFT_DEMO_SAC_USER, CRAFT_DEMO_SAC_PROJECT, CRAFT_DEMO_SAC_VERSION, simulation_id,'src/decision/ContextualAlerts.bt',  data)
 		# Start update simulation in a thread
 		stateVar.t_simulation = UpdateLifeThreadClass()
 		stateVar.t_simulation.start()


### PR DESCRIPTION
- use **resource path** to reference BTs in API calls and embedded nodes
- use **https** to connect to the **craft ai** API 